### PR TITLE
SWC-8 endpoint ingreso nombre fix

### DIFF
--- a/endpoint_nombre.py
+++ b/endpoint_nombre.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Body
 from pydantic import BaseModel, Field
-from typing import Annotated 
+from typing import Annotated
 
 from model.player import Player
 from main import app, player_repo
@@ -9,7 +9,8 @@ from main import app, player_repo
 class Name(BaseModel):
     name: str = Field(min_length=1, max_length=64)
 
+
 @app.post("/api/name")
 async def take_nickname(nickname: Name) -> Name:
-    player_repo.save(Player(name = nickname.name))
+    player_repo.save(Player(name=nickname.name))
     return nickname

--- a/main.py
+++ b/main.py
@@ -1,9 +1,13 @@
 from os import getenv
+from uuid import uuid4, UUID
 from fastapi import FastAPI, Response, Request, Depends
 from sqlalchemy.orm import Session
+from pydantic import BaseModel, Field
 
 from database import Database
 from repositories import GameRepository, PlayerRepository
+from model import Player
+
 
 db_uri = getenv("DB_URI")
 if db_uri is not None:
@@ -15,14 +19,14 @@ db.create_tables()
 # creamos la App
 app = FastAPI()
 
-# inicialicemos los repos 
 player_repo = PlayerRepository(db.session())
 game_repo = GameRepository(db.session())
-# #no seria Database().get.session()? 
+
 
 @app.middleware("http")
-async def add_game_repo_to_request(request: Request, call_next):
+async def add_repos_to_request(request: Request, call_next):
     request.state.game_repo = game_repo
+    request.state.player_repo = player_repo
     response = await call_next(request)
     return response
 
@@ -31,8 +35,21 @@ def get_games_repo(request: Request) -> GameRepository:
     return request.state.game_repo
 
 
-# endpoing juguete, borralo cuando haya uno de verdad
-@app.get("/api/borrame")
-async def borrame(games_repo: GameRepository = Depends(get_games_repo)):
-    games = games_repo.get_many(10)
-    return {"games": games}
+def get_player_repo(request: Request) -> PlayerRepository:
+    return request.state.player_repo
+
+
+class SetNameRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=64)
+
+
+class SetNameResponse(BaseModel):
+    name: str = Field()
+    identifier: UUID = Field()
+
+
+@app.post("/api/name")
+async def set_player_name(setNameRequest: SetNameRequest) -> SetNameResponse:
+    identifier = uuid4()
+    player_repo.save(Player(name=setNameRequest.name, identifier=identifier))
+    return SetNameResponse(name=setNameRequest.name, identifier=identifier)

--- a/main.py
+++ b/main.py
@@ -49,7 +49,10 @@ class SetNameResponse(BaseModel):
 
 
 @app.post("/api/name")
-async def set_player_name(setNameRequest: SetNameRequest) -> SetNameResponse:
+async def set_player_name(
+    setNameRequest: SetNameRequest,
+    player_repo: PlayerRepository = Depends(get_player_repo),
+) -> SetNameResponse:
     identifier = uuid4()
     player_repo.save(Player(name=setNameRequest.name, identifier=identifier))
     return SetNameResponse(name=setNameRequest.name, identifier=identifier)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from os import getenv
 from uuid import uuid4, UUID
 from fastapi import FastAPI, Response, Request, Depends
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
 
@@ -21,6 +22,15 @@ app = FastAPI()
 
 player_repo = PlayerRepository(db.session())
 game_repo = GameRepository(db.session())
+
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.middleware("http")

--- a/model/player.py
+++ b/model/player.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import mapped_column, Mapped
-from sqlalchemy.types import Integer, String
+from sqlalchemy.types import UUID, Integer, String
 
 from database import Base
 
@@ -9,5 +9,6 @@ class Player(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String(64), nullable=False)
+    identifier: Mapped[str] = mapped_column(UUID, nullable=False)
     host: Mapped[bool] = mapped_column(Integer, default=False, nullable=False)
     on_game: Mapped[bool] = mapped_column(Integer, default=False, nullable=False)

--- a/repositories/test_player.py
+++ b/repositories/test_player.py
@@ -1,4 +1,5 @@
 import unittest
+from uuid import uuid4
 
 import asserts
 
@@ -7,14 +8,17 @@ from repositories import PlayerRepository
 from database import Database
 
 
+def make_player(name: str) -> Player:
+    return Player(name=name, identifier=uuid4())
+
+
 class TestGameRepo(unittest.TestCase):
     def repo(self):
         return PlayerRepository(Database().session())
-    #no seria Database().get.session()? 
 
     def test_new_player(self):
         repo = self.repo()
-        p = Player(name="Alice")
+        p = make_player("Alice")
         repo.save(p)
         self.assertIsNotNone(p.id)
         saved_player = repo.get(p.id)
@@ -23,7 +27,7 @@ class TestGameRepo(unittest.TestCase):
 
     def test_delete_player(self):
         repo = self.repo()
-        players = [Player(name="Alice"), Player(name="Bob"), Player(name="Carl")]
+        players = [make_player("Alice"), make_player("Bob"), make_player("Carl")]
         for p in players:
             repo.save(p)
         alice = players[0]

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -8,6 +8,7 @@ client = TestClient(app)
 
 
 def test_borrame():
-    response = client.get("/api/borrame")
+    response = client.post("/api/name", json={"name": "pepe"})
     asserts.assert_equal(response.status_code, 200)
-    asserts.assert_equal(response.json(), {"games": []})
+    rsp = response.json()
+    asserts.assert_equal(rsp["name"], "pepe")


### PR DESCRIPTION
Este PR arregla el endpoint para que sea funcional.
Nota: No completa el ticket, hay que escribir las tests del endpoint como corresponde, y testear pedir el Player por su identificador que es importante para los comandos.

Hay que borrar `endpoint_nombre.py` ya que este archivo no hace nada.
Pero con esta rama el endpoint ya corre y se puede hacer pruebas de integracion.