### PR TITLE
SWC-96 estado tablero

### DIFF
--- a/main.py
+++ b/main.py
@@ -590,3 +590,41 @@ async def lobby_notify_status(websocket: WebSocket, game_id: int, player_id: int
             data = await websocket.receive_json()
     except WebSocketDisconnect:
         manager.disconnect(game_id, player_id)
+
+
+@app.websocket("/ws/lobby/{game_id}/board")
+async def lobby_notify_board(websocket: WebSocket, game_id: int, player_id: int):
+    """
+    Este WS se encarga de notificar el estado del tablero a los jugadores conectados.
+    Retorna mensajes de la siguiente forma:
+        {
+            "game_id": int,
+            "board": [int]
+        }
+    Tambien se puede recibir pedidos del estado del tablero usando el siguiente mensaje:
+        {
+            "request": "status"
+        }
+    """
+    manager = Managers.get_manager(ManagerTypes.BOARD_STATUS)
+    await manager.connect(websocket, game_id, player_id)
+    try:
+        while True:
+            data = await websocket.receive_json()
+            request = data.get("request")
+            if request is None or request != "status":
+                await websocket.send_json({"error": "invalid request"})
+                continue
+            game = game_repo.get(game_id)
+            if game is None:
+                await websocket.send_json({"error": "invalid game id"})
+                continue
+            board = [tile.value for tile in game.board]
+            await websocket.send_json(
+                {
+                    "game_id": game_id,
+                    "board": board,
+                }
+            )
+    except WebSocketDisconnect:
+        manager.disconnect(game_id, player_id)

--- a/services/connection_manager.py
+++ b/services/connection_manager.py
@@ -9,6 +9,7 @@ class ManagerTypes(Enum):
     JOIN_LEAVE = 1
     TURNS = 2
     GAME_STATUS = 3
+    BOARD_STATUS = 4
 
 
 @dataclass
@@ -51,6 +52,7 @@ class Managers:
         ManagerTypes.JOIN_LEAVE: ConnectionManager(),
         ManagerTypes.TURNS: ConnectionManager(),
         ManagerTypes.GAME_STATUS: ConnectionManager(),
+        ManagerTypes.BOARD_STATUS: ConnectionManager(),
     }
 
     @classmethod

--- a/tests/test_board_status.py
+++ b/tests/test_board_status.py
@@ -1,0 +1,97 @@
+import unittest
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from database import Database
+from main import app
+from model import Game, Player
+from repositories import GameRepository, PlayerRepository
+
+client = TestClient(app)
+
+
+class TestBoardStatus(unittest.TestCase):
+
+    def setUp(self):
+        self.client = TestClient(app)
+        self.dbs = Database().session()
+        self.games_repo = GameRepository(self.dbs)
+        self.player_repo = PlayerRepository(self.dbs)
+
+        self.host = Player(name="Ely")
+        self.player_repo.save(self.host)
+
+        self.players = [
+            Player(name="Lou"),
+            Player(name="Lou^2"),
+            Player(name="Andy"),
+        ]
+        for p in self.players:
+            self.player_repo.save(p)
+        self.game_1 = Game(
+            name="Game of Falls",
+            current_player_turn=0,
+            max_players=4,
+            min_players=2,
+            started=False,
+            players=[self.players[0]],
+            host=self.host,
+            host_id=self.host.id,
+        )
+
+        self.game_2 = Game(
+            name="Game of Thrones",
+            current_player_turn=0,
+            max_players=4,
+            min_players=2,
+            started=False,
+            players=self.players[1:3],
+            host=self.host,
+            host_id=self.host.id,
+        )
+
+        self.games_repo.save(self.game_1)
+        self.games_repo.save(self.game_2)
+
+    def tearDown(self):
+        self.dbs.query(Game).delete()
+        self.dbs.query(Player).delete()
+        self.dbs.commit()
+        self.dbs.close()
+
+    def test_board_status_invalid_game(self):
+        with patch("main.game_repo", self.games_repo), patch(
+            "main.player_repo", self.player_repo
+        ), self.client.websocket_connect(
+            f"/ws/lobby/9999/board?player_id={self.players[0].id}"
+        ) as ws:
+            ws.send_json({"request": "status"})
+            msg = ws.receive_json()
+            self.assertIn("error", msg)
+            self.assertEqual(msg["error"], "invalid game id")
+
+    def test_board_status_invalid_request(self):
+        with patch("main.game_repo", self.games_repo), patch(
+            "main.player_repo", self.player_repo
+        ), self.client.websocket_connect(
+            f"/ws/lobby/{self.game_1.id}/board?player_id={self.players[0].id}"
+        ) as ws:
+            ws.send_json({"request": "invalid"})
+            msg = ws.receive_json()
+            self.assertIn("error", msg)
+            self.assertEqual(msg["error"], "invalid request")
+
+    def test_board_status_valid_game(self):
+        with patch("main.game_repo", self.games_repo), patch(
+            "main.player_repo", self.player_repo
+        ), self.client.websocket_connect(
+            f"/ws/lobby/{self.game_1.id}/board?player_id={self.players[0].id}"
+        ) as ws:
+            ws.send_json({"request": "status"})
+            msg = ws.receive_json()
+            self.assertIn("game_id", msg)
+            self.assertIn("board", msg)
+            self.assertEqual(msg["game_id"], self.game_1.id)
+            self.assertEqual(msg["board"], [tile.value for tile in self.game_1.board])


### PR DESCRIPTION
Este PR agrega un ws en `ws/lobby/{game_id}/board` que notifica de cambios en el tablero y da una lista de las fichas en el tablero.