### PR TITLE
SWC-93 endpoint usar carta movimiento correcciones

### DIFF
--- a/tests/test_play_card.py
+++ b/tests/test_play_card.py
@@ -63,7 +63,7 @@ class TestPlayCard(unittest.TestCase):
             status = self.client.post(
                 f"/api/game/{self.game.id}/play_card",
                 json={
-                    "player_id": self.players[0].id,
+                    "identifier": str(self.players[0].identifier),
                     "origin_tile": 0,
                     "dest_tile": 1,
                     "card_mov_id": 3,
@@ -101,7 +101,7 @@ class TestPlayCard(unittest.TestCase):
                     status = self.client.post(
                         f"/api/game/{self.game.id}/play_card",
                         json={
-                            "player_id": self.players[0].id,
+                            "identifier": str(self.players[0].identifier),
                             "origin_tile": 0,
                             "dest_tile": 1,
                             "card_mov_id": 3,
@@ -110,14 +110,14 @@ class TestPlayCard(unittest.TestCase):
                     )
                     assert status.status_code == 200
 
-                    assert websocket.receive_json() == {
-                        "game_id": self.game.id,
-                        "board": [tile.value for tile in self.game.board],
-                    }
-                    assert websocket2.receive_json() == {
-                        "game_id": self.game.id,
-                        "board": [tile.value for tile in self.game.board],
-                    }
+                    board = [tile.value for tile in self.game.board]
+                    rsp = websocket.receive_json()
+                    assert rsp["game_id"] == self.game.id
+                    assert rsp["board"] == board
+
+                    rsp = websocket2.receive_json()
+                    assert rsp["game_id"] == self.game.id
+                    assert rsp["board"] == board
 
     def test_ws_hand_play(self):
         with patch("main.game_repo", self.games_repo), patch(
@@ -142,7 +142,7 @@ class TestPlayCard(unittest.TestCase):
                     status = self.client.post(
                         f"/api/game/{self.game.id}/play_card",
                         json={
-                            "player_id": self.players[0].id,
+                            "identifier": str(self.players[0].identifier),
                             "origin_tile": 0,
                             "dest_tile": 1,
                             "card_mov_id": 3,
@@ -175,7 +175,7 @@ class TestPlayCard(unittest.TestCase):
             status = self.client.post(
                 f"/api/game/{self.game.id}/play_card",
                 json={
-                    "player_id": self.players[0].id,
+                    "identifier": str(self.players[0].identifier),
                     "origin_tile": 0,
                     "dest_tile": 0,
                     "card_mov_id": 3,
@@ -197,7 +197,7 @@ class TestPlayCard(unittest.TestCase):
             status = self.client.post(
                 f"/api/game/{self.game.id}/play_card",
                 json={
-                    "player_id": self.players[0].id,
+                    "identifier": str(self.players[0].identifier),
                     "origin_tile": 0,
                     "dest_tile": 1,
                     "card_mov_id": 4,
@@ -223,7 +223,7 @@ class TestPlayCard(unittest.TestCase):
             status = self.client.post(
                 f"/api/game/{self.game.id}/play_card",
                 json={
-                    "player_id": self.players[2].id,
+                    "identifier": str(self.players[2].identifier),
                     "origin_tile": 0,
                     "dest_tile": 1,
                     "card_mov_id": 3,
@@ -236,7 +236,7 @@ class TestPlayCard(unittest.TestCase):
             status = self.client.post(
                 f"/api/game/{self.game.id}/play_card",
                 json={
-                    "player_id": self.game.players[1].id,
+                    "identifier": str(self.players[1].identifier),
                     "origin_tile": 0,
                     "dest_tile": 1,
                     "card_mov_id": 3,

--- a/tests/test_undo_move.py
+++ b/tests/test_undo_move.py
@@ -63,7 +63,7 @@ class TestPlayCardAndUndoMove(unittest.TestCase):
             status = self.client.post(
                 f"/api/game/{self.game.id}/play_card",
                 json={
-                    "player_id": self.players[0].id,
+                    "identifier": str(self.players[0].identifier),
                     "origin_tile": 0,
                     "dest_tile": 1,
                     "card_mov_id": 3,
@@ -75,7 +75,8 @@ class TestPlayCardAndUndoMove(unittest.TestCase):
             print("HISTORY BEFORE UNDO: ", history.json())
 
             status = self.client.post(
-                f"/api/game/{self.game.id}/undo?player_id={self.players[0].id}"
+                f"/api/game/{self.game.id}/undo",
+                json={"identifier": str(self.players[0].identifier)},
             )
 
             print("STATUS: ", status.json())
@@ -114,7 +115,7 @@ class TestPlayCardAndUndoMove(unittest.TestCase):
                     status = self.client.post(
                         f"/api/game/{self.game.id}/play_card",
                         json={
-                            "player_id": self.players[0].id,
+                            "identifier": str(self.players[0].identifier),
                             "origin_tile": 0,
                             "dest_tile": 1,
                             "card_mov_id": 3,
@@ -124,17 +125,18 @@ class TestPlayCardAndUndoMove(unittest.TestCase):
                     assert status.status_code == 200
 
                     status = self.client.post(
-                        f"/api/game/{self.game.id}/undo?player_id={self.players[0].id}"
+                        f"/api/game/{self.game.id}/undo",
+                        json={
+                            "identifier": str(self.players[0].identifier),
+                        },
                     )
                     assert status.status_code == 200
-                    assert websocket.receive_json() == {
-                        "game_id": self.game.id,
-                        "board": board_before,
-                    }
-                    assert websocket2.receive_json() == {
-                        "game_id": self.game.id,
-                        "board": board_before,
-                    }
+                    rsp = websocket.receive_json()
+                    assert rsp["game_id"] == self.game.id
+                    assert rsp["board"] == board_before
+                    rsp = websocket2.receive_json()
+                    assert rsp["game_id"] == self.game.id
+                    assert rsp["board"] == board_before
 
     def test_ws_hand_undo(self):
         with patch("main.game_repo", self.games_repo), patch(
@@ -159,7 +161,7 @@ class TestPlayCardAndUndoMove(unittest.TestCase):
                     status = self.client.post(
                         f"/api/game/{self.game.id}/play_card",
                         json={
-                            "player_id": self.players[0].id,
+                            "identifier": str(self.players[0].identifier),
                             "origin_tile": 0,
                             "dest_tile": 1,
                             "card_mov_id": 3,
@@ -170,7 +172,10 @@ class TestPlayCardAndUndoMove(unittest.TestCase):
                     websocket.receive_json()
                     websocket2.receive_json()
                     status = self.client.post(
-                        f"/api/game/{self.game.id}/undo?player_id={self.players[0].id}"
+                        f"/api/game/{self.game.id}/undo",
+                        json={
+                            "identifier": str(self.players[0].identifier),
+                        },
                     )
                     assert status.status_code == 200
                     assert websocket.receive_json() == {
@@ -200,7 +205,7 @@ class TestPlayCardAndUndoMove(unittest.TestCase):
             self.client.post(
                 f"/api/game/{self.game.id}/play_card",
                 json={
-                    "player_id": self.players[0].id,
+                    "identifier": str(self.players[0].identifier),
                     "origin_tile": 0,
                     "dest_tile": 1,
                     "card_mov_id": 3,
@@ -211,7 +216,10 @@ class TestPlayCardAndUndoMove(unittest.TestCase):
             self.game.advance_turn()
 
             status = self.client.post(
-                f"/api/game/{self.game.id}/undo?player_id={self.players[1].id}"
+                f"/api/game/{self.game.id}/undo",
+                json={
+                    "identifier": str(self.players[1].identifier),
+                },
             )
             assert status.status_code == 404
             assert status.json() == {"detail": "Nothing to undo"}


### PR DESCRIPTION
Este PR corrige el uso incorrecto del player_id en vez del identifier. Toda accion de jugador debe ser validad que es ejecutada por el jugador en cuestion y no Domingo Peron.