### PR TITLE
Swc 187 modificar el endpoint de listar partidas

### DIFF
--- a/main.py
+++ b/main.py
@@ -583,7 +583,7 @@ async def turn_change_notifier(websocket: WebSocket, game_id: int, player_id: in
 async def lobby_notify_inout(websocket: WebSocket, game_id: int, player_id: int):
     """
     Este ws se encarga de notificar a los usuarios conectados dentro de un juego cuando otro usuario se conecta o desconecta, enviando la lista
-    actualizada de jugadores actuales.
+    actualizada de jugadores actuales, tambien los agrega a la DB.
 
     Se espera: {user_identifier: 'str'}
 
@@ -611,6 +611,12 @@ async def lobby_notify_inout(websocket: WebSocket, game_id: int, player_id: int)
             if player is None:
                 await websocket.send_json({"error": "Player not found"})
                 continue
+
+            seed_password = data.get("password")
+            if seed_password is not None:
+                if not pwd_context.verify(seed_password, game.password):
+                    await websocket.send_json({"error": "Invalid password"})
+                    continue
 
             game.add_player(player)
             game_repo.save(game)

--- a/main.py
+++ b/main.py
@@ -92,9 +92,9 @@ async def create_game(
     game_repo: GameRepository = Depends(get_games_repo),
     player_repo: PlayerRepository = Depends(get_player_repo),
 ) -> GameOut:
-    '''
+    """
     Crea un nuevo juego en el lobby
-    '''
+    """
 
     if game_create.min_players > game_create.max_players:
         raise HTTPException(
@@ -112,7 +112,7 @@ async def create_game(
         max_players=game_create.max_players,
         min_players=game_create.min_players,
         started=False,
-        is_private= game_create.is_private,
+        is_private=game_create.is_private,
     )
     new_game.add_player(player)
     game_repo.save(new_game)
@@ -150,9 +150,9 @@ def get_games_available(
     max_players: Optional[int] = None,
     name: Optional[str] = None,
 ) -> List[GameStateOutput]:
-    ''' 
+    """
     Retorna una lista de juegos disponibles
-    '''
+    """
     params: Dict[str, Any] = {
         "count": 10,
     }
@@ -383,6 +383,7 @@ class ExitRequest(BaseModel):  # le llega esto al endpoint
 def check_victory(game: Game):
     return game.started and len(game.players) == 1
 
+
 async def nuke_game(game: Game, games_repo: GameRepository):
     games_repo.delete(game)
     await Managers.disconnect_all(game.id)
@@ -478,7 +479,7 @@ async def advance_game_turn(
 
 @app.post("/api/lobby/{game_id}/movs", response_model=SetCardsResponse)
 async def deal_card_mov(
-    game_id : int,
+    game_id: int,
     req: GameIn2,
     player_repo: PlayerRepository = Depends(get_player_repo),
     games_repo: GameRepository = Depends(get_games_repo),
@@ -498,7 +499,7 @@ async def deal_card_mov(
     count = TOTAL_HAND_MOV - len(mov_hand)
     movs_in_game = in_game.all_movs
     conjunto = set()
-    while(len(conjunto) < count):
+    while len(conjunto) < count:
         conjunto.add(random.choice(movs_in_game))
     cards = list(conjunto)
     mov_hand.extend(cards)
@@ -883,7 +884,7 @@ async def undo_move(
     game.swap_tiles(
         last_play.dest_x, last_play.dest_y, last_play.origin_x, last_play.origin_y
     )
-    # recordar que aplica sobre la mano de movimientos parciales del jugador 
+    # recordar que aplica sobre la mano de movimientos parciales del jugador
     game.remove_single_mov(player.id, last_play.fig_mov_id)
 
     history_repo.delete(last_play)

--- a/main.py
+++ b/main.py
@@ -87,7 +87,6 @@ class GameOut(BaseModel):
     min_players: int
     started: bool
     is_private: bool
-    password: Optional[str] = None
     players: List[PlayerOut]
 
 
@@ -105,11 +104,6 @@ async def create_game(
         raise HTTPException(
             status_code=412,
             detail="El número mínimo de jugadores no puede ser mayor al máximo",
-        )
-    if game_create.min_players < 2 or game_create.max_players > 4:
-        raise HTTPException(
-            status_code=412,
-            detail="El número de jugadores debe estar entre 2 y 4",
         )
     if game_create.is_private and game_create.password is None:
         raise HTTPException(
@@ -149,7 +143,6 @@ async def create_game(
         started=new_game.started,
         is_private=new_game.is_private,
         players=players_out,
-        password=new_game.password,
     )
 
 

--- a/main.py
+++ b/main.py
@@ -3,11 +3,11 @@ import random
 from os import getenv
 from typing import Any, Dict, List, Optional
 from uuid import UUID, uuid4
-from passlib.context import CryptContext
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.websockets import WebSocket, WebSocketDisconnect
+from passlib.context import CryptContext
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 

--- a/model/game.py
+++ b/model/game.py
@@ -103,6 +103,7 @@ class Game(Base):
     )
     all_movs: Mapped[List[int]] = mapped_column(IdMov, default=IdMov.total)
     is_private: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    password: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/model/game.py
+++ b/model/game.py
@@ -102,6 +102,7 @@ class Game(Base):
         PlayerInfoMapper, default=lambda: {}
     )
     all_movs: Mapped[List[int]] = mapped_column(IdMov, default=IdMov.total)
+    is_private: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -128,6 +129,7 @@ class Game(Base):
             and self.min_players == other.min_players
             and self.started == other.started
             and self.players == other.players
+            and self.is_private == other.is_private
         )
 
     def set_defaults(self):
@@ -150,7 +152,7 @@ class Game(Base):
         return (
             f"<Game(id={self.id}, name={self.name}, current_player_turn={self.current_player_turn}, "
             f"max_players={self.max_players}, min_players={self.min_players}, started={self.started}, "
-            f"host_id={self.host_id})>"
+            f"host_id={self.host_id}, is_private={self.is_private})>"
         )
 
     def advance_player(self):

--- a/model/game.py
+++ b/model/game.py
@@ -46,7 +46,7 @@ class PlayerInfo:
             "hand_fig": self.hand_fig,
             "hand_mov": self.hand_mov,
             "fig": self.fig,
-            "mov_parcial": self.mov_parcial
+            "mov_parcial": self.mov_parcial,
         }
 
     @staticmethod
@@ -57,7 +57,7 @@ class PlayerInfo:
             hand_fig=data["hand_fig"],
             hand_mov=data["hand_mov"],
             fig=data["fig"],
-            mov_parcial=data["mov_parcial"]
+            mov_parcial=data["mov_parcial"],
         )
 
 
@@ -115,7 +115,7 @@ class Game(Base):
                     hand_fig=[],
                     hand_mov=[],
                     fig=[],
-                    mov_parcial=[]
+                    mov_parcial=[],
                 )
 
     def __eq__(self, other):
@@ -172,7 +172,7 @@ class Game(Base):
             hand_fig=[],
             hand_mov=[],
             fig=list(range(1, TOTAL_FIG_CARDS + 1)),
-            mov_parcial=[]
+            mov_parcial=[],
         )
 
     def count_players(self) -> int:
@@ -258,10 +258,10 @@ class Game(Base):
 
     def get_player_hand_movs(self, player_id: int) -> List[int]:
         return self.player_info[player_id].hand_mov
-    
+
     def get_player_mov_parcial(self, player_id: int):
         return self.player_info[player_id].mov_parcial
-    
+
     def swap_tiles(self, origin_x: int, origin_y: int, dest_x: int, dest_y: int):
         origin_index = origin_x + origin_y * 6
         dest_index = dest_x + dest_y * 6

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest-mock==3.14.0
 APScheduler==3.10.4
 coverage==7.6.1
 isort==5.13.2
+passlib==1.7.4

--- a/tests/test_create_game.py
+++ b/tests/test_create_game.py
@@ -21,7 +21,7 @@ def test_create_game():
     host = Player(name="host", identifier=test_identifier)
     player_repo.save(host)
 
-    # Guarda al jugador usando el endpoint
+    # Crea una partida y unimos al host usando el endpoint
     response = client.post(
         "/api/lobby",
         json={
@@ -29,8 +29,10 @@ def test_create_game():
             "name": "partida1",
             "max_players": 4,
             "min_players": 2,
+            "is_private": False,
         },
     )
+    print(response.json())
 
     # Verifica el estado de la respuesta
     assert response.status_code == 200
@@ -56,6 +58,7 @@ def test_crear_partida_error_min_mayor_max(mock_game_repo):
             "name": "partida1",
             "max_players": 3,
             "min_players": 4,
+            "is_private": True,
         },
     )
     assert response.status_code == 412
@@ -73,6 +76,7 @@ def test_crear_partida_error_min_jugadores_invalido(mock_game_repo):
             "name": "partida1",
             "max_players": 4,
             "min_players": 1,
+            "is_private": True,
         },
     )
     assert response.status_code == 422
@@ -87,6 +91,7 @@ def test_crear_partida_nombre_vacio(mock_game_repo):
             "name": "",
             "max_players": 4,
             "min_players": 2,
+            "is_private": True,
         },
     )
     assert response.status_code == 422
@@ -128,6 +133,7 @@ def test_creaar_partida_jugador_no_encontrado():
             "name": "partida1",
             "max_players": 4,
             "min_players": 2,
+            "is_private": False,
         },
     )
     assert response.status_code == 404

--- a/tests/test_get_game.py
+++ b/tests/test_get_game.py
@@ -16,6 +16,7 @@ data_out = Game(
     max_players=4,
     min_players=2,
     started=False,
+    is_private=False,
     players=[Player(id=1, name="Player 1"), Player(id=2, name="Player 2")],
 )
 
@@ -33,6 +34,7 @@ def test_get_game():
             "min_players": 2,
             "started": False,
             "turn": 0,
+            "is_private": False,
             "players": ["Player 1", "Player 2"],
         }
 

--- a/tests/test_notify_lobby.py
+++ b/tests/test_notify_lobby.py
@@ -85,7 +85,10 @@ class TestNotifyLobby(unittest.TestCase):
                 response = websocket0.receive_json()
                 assert response == {
                     "players": [
-                        {"player_id": id0, "player_name": self.game_public.players[0].name}
+                        {
+                            "player_id": id0,
+                            "player_name": self.game_public.players[0].name,
+                        }
                     ]
                 }
 
@@ -111,84 +114,94 @@ class TestNotifyLobby(unittest.TestCase):
                     }
 
         def test_connect_from_lobby_private(self):
-                
-                with patch("main.game_repo", self.games_repo), patch(
-                    "main.player_repo", self.player_repo
-                ):
-    
-                    identifier0 = self.players[0].identifier
-                    indetifier1 = self.players[1].identifier
-                    id0 = self.players[0].id
-                    id1 = self.players[1].id
-    
+
+            with patch("main.game_repo", self.games_repo), patch(
+                "main.player_repo", self.player_repo
+            ):
+
+                identifier0 = self.players[0].identifier
+                indetifier1 = self.players[1].identifier
+                id0 = self.players[0].id
+                id1 = self.players[1].id
+
+                with self.client.websocket_connect(
+                    f"/ws/lobby/2?player_id={id0}"
+                ) as websocket0:
+
+                    websocket0.send_json({"user_identifier": str(identifier0)})
+
+                    # Chequeamos que estemos solos
+                    response = websocket0.receive_json()
+                    assert response == {
+                        "players": [
+                            {
+                                "player_id": id0,
+                                "player_name": self.game_private.players[0].name,
+                            }
+                        ]
+                    }
+
                     with self.client.websocket_connect(
-                        f"/ws/lobby/2?player_id={id0}"
-                    ) as websocket0:
-    
-                        websocket0.send_json({"user_identifier": str(identifier0)})
-    
-                        # Chequeamos que estemos solos
-                        response = websocket0.receive_json()
+                        f"/ws/lobby/2?player_id={id1}"
+                    ) as websocket1:
+
+                        websocket1.send_json(
+                            {"user_identifier": str(indetifier1), "password": "1234"}
+                        )
+
+                        # Chequeamos que estemos los dos y que la contraseña es correcta
+                        response = websocket1.receive_json()
                         assert response == {
                             "players": [
-                                {"player_id": id0, "player_name": self.game_private.players[0].name}
-                            ]
+                                {
+                                    "player_id": id0,
+                                    "player_name": self.game_private.players[0].name,
+                                },
+                                {
+                                    "player_id": id1,
+                                    "player_name": self.game_private.players[1].name,
+                                },
+                            ],
                         }
-    
-                        with self.client.websocket_connect(
-                            f"/ws/lobby/2?player_id={id1}"
-                        ) as websocket1:
-    
-                            websocket1.send_json({"user_identifier": str(indetifier1), "password": "1234"})
-    
-                            # Chequeamos que estemos los dos y que la contraseña es correcta
-                            response = websocket1.receive_json()
-                            assert response == {
-                                "players": [
-                                    {
-                                        "player_id": id0,
-                                        "player_name": self.game_private.players[0].name,
-                                    },
-                                    {
-                                        "player_id": id1,
-                                        "player_name": self.game_private.players[1].name,
-                                    },
-                                ],
-                            }
 
         def test_connect_from_lobby_private_password_incorrect(self):
-                    
-                    with patch("main.game_repo", self.games_repo), patch(
-                        "main.player_repo", self.player_repo
-                    ):
-        
-                        identifier0 = self.players[0].identifier
-                        indetifier1 = self.players[1].identifier
-                        id0 = self.players[0].id
-                        id1 = self.players[1].id
-        
-                        with self.client.websocket_connect(
-                            f"/ws/lobby/2?player_id={id0}"
-                        ) as websocket0:
-        
-                            websocket0.send_json({"user_identifier": str(identifier0)})
-        
-                            # Chequeamos que estemos solos
-                            response = websocket0.receive_json()
-                            assert response == {
-                                "players": [
-                                    {"player_id": id0, "player_name": self.game_private.players[0].name}
-                                ]
+
+            with patch("main.game_repo", self.games_repo), patch(
+                "main.player_repo", self.player_repo
+            ):
+
+                identifier0 = self.players[0].identifier
+                indetifier1 = self.players[1].identifier
+                id0 = self.players[0].id
+                id1 = self.players[1].id
+
+                with self.client.websocket_connect(
+                    f"/ws/lobby/2?player_id={id0}"
+                ) as websocket0:
+
+                    websocket0.send_json({"user_identifier": str(identifier0)})
+
+                    # Chequeamos que estemos solos
+                    response = websocket0.receive_json()
+                    assert response == {
+                        "players": [
+                            {
+                                "player_id": id0,
+                                "player_name": self.game_private.players[0].name,
                             }
-        
-                            with self.client.websocket_connect(
-                                f"/ws/lobby/2?player_id={id1}"
-                            ) as websocket1:
-        
-                                websocket1.send_json({"user_identifier": str(indetifier1), "password": "12345"})
-        
-                                # Chequeamos que la efectivamente la contraseña es incorrecta
-                                response = websocket1.receive_json()
-                                assert response == {
-                                    "error": "Incorrect password",
-                                }
+                        ]
+                    }
+
+                    with self.client.websocket_connect(
+                        f"/ws/lobby/2?player_id={id1}"
+                    ) as websocket1:
+
+                        websocket1.send_json(
+                            {"user_identifier": str(indetifier1), "password": "12345"}
+                        )
+
+                        # Chequeamos que la efectivamente la contraseña es incorrecta
+                        response = websocket1.receive_json()
+                        assert response == {
+                            "error": "Incorrect password",
+                        }

--- a/tests/test_notify_lobby.py
+++ b/tests/test_notify_lobby.py
@@ -29,7 +29,7 @@ class TestNotifyLobby(unittest.TestCase):
         for p in self.players:
             self.player_repo.save(p)
 
-        self.game_1 = Game(
+        self.game_public = Game(
             id=1,
             name="Game of Falls",
             current_player_turn=0,
@@ -39,9 +39,24 @@ class TestNotifyLobby(unittest.TestCase):
             players=[],
             host=self.host,
             host_id=self.host.id,
+            is_private=False,
         )
 
-        self.games_repo.save(self.game_1)
+        self.game_private = Game(
+            id=2,
+            name="Game of Thrones Private",
+            current_player_turn=0,
+            max_players=4,
+            min_players=2,
+            started=False,
+            players=[],
+            host=self.host,
+            host_id=self.host.id,
+            is_private=True,
+            password="1234",
+        )
+
+        self.games_repo.save(self.game_public)
 
     def tearDown(self):
         self.dbs.query(Game).delete()
@@ -49,7 +64,7 @@ class TestNotifyLobby(unittest.TestCase):
         self.dbs.commit()
         self.dbs.close()
 
-    def test_connect_from_lobby(self):
+    def test_connect_from_lobby_public(self):
 
         with patch("main.game_repo", self.games_repo), patch(
             "main.player_repo", self.player_repo
@@ -60,8 +75,6 @@ class TestNotifyLobby(unittest.TestCase):
             id0 = self.players[0].id
             id1 = self.players[1].id
 
-            # Se une el Lou
-            self.game_1.add_player(self.players[0])
             with self.client.websocket_connect(
                 f"/ws/lobby/1?player_id={id0}"
             ) as websocket0:
@@ -72,12 +85,10 @@ class TestNotifyLobby(unittest.TestCase):
                 response = websocket0.receive_json()
                 assert response == {
                     "players": [
-                        {"player_id": id0, "player_name": self.game_1.players[0].name}
+                        {"player_id": id0, "player_name": self.game_public.players[0].name}
                     ]
                 }
 
-                # Se une el Lou^2
-                self.game_1.add_player(self.players[1])
                 with self.client.websocket_connect(
                     f"/ws/lobby/1?player_id={id1}"
                 ) as websocket1:
@@ -90,11 +101,94 @@ class TestNotifyLobby(unittest.TestCase):
                         "players": [
                             {
                                 "player_id": id0,
-                                "player_name": self.game_1.players[0].name,
+                                "player_name": self.game_public.players[0].name,
                             },
                             {
                                 "player_id": id1,
-                                "player_name": self.game_1.players[1].name,
+                                "player_name": self.game_public.players[1].name,
                             },
                         ],
                     }
+
+        def test_connect_from_lobby_private(self):
+                
+                with patch("main.game_repo", self.games_repo), patch(
+                    "main.player_repo", self.player_repo
+                ):
+    
+                    identifier0 = self.players[0].identifier
+                    indetifier1 = self.players[1].identifier
+                    id0 = self.players[0].id
+                    id1 = self.players[1].id
+    
+                    with self.client.websocket_connect(
+                        f"/ws/lobby/2?player_id={id0}"
+                    ) as websocket0:
+    
+                        websocket0.send_json({"user_identifier": str(identifier0)})
+    
+                        # Chequeamos que estemos solos
+                        response = websocket0.receive_json()
+                        assert response == {
+                            "players": [
+                                {"player_id": id0, "player_name": self.game_private.players[0].name}
+                            ]
+                        }
+    
+                        with self.client.websocket_connect(
+                            f"/ws/lobby/2?player_id={id1}"
+                        ) as websocket1:
+    
+                            websocket1.send_json({"user_identifier": str(indetifier1), "password": "1234"})
+    
+                            # Chequeamos que estemos los dos y que la contraseña es correcta
+                            response = websocket1.receive_json()
+                            assert response == {
+                                "players": [
+                                    {
+                                        "player_id": id0,
+                                        "player_name": self.game_private.players[0].name,
+                                    },
+                                    {
+                                        "player_id": id1,
+                                        "player_name": self.game_private.players[1].name,
+                                    },
+                                ],
+                            }
+
+        def test_connect_from_lobby_private_password_incorrect(self):
+                    
+                    with patch("main.game_repo", self.games_repo), patch(
+                        "main.player_repo", self.player_repo
+                    ):
+        
+                        identifier0 = self.players[0].identifier
+                        indetifier1 = self.players[1].identifier
+                        id0 = self.players[0].id
+                        id1 = self.players[1].id
+        
+                        with self.client.websocket_connect(
+                            f"/ws/lobby/2?player_id={id0}"
+                        ) as websocket0:
+        
+                            websocket0.send_json({"user_identifier": str(identifier0)})
+        
+                            # Chequeamos que estemos solos
+                            response = websocket0.receive_json()
+                            assert response == {
+                                "players": [
+                                    {"player_id": id0, "player_name": self.game_private.players[0].name}
+                                ]
+                            }
+        
+                            with self.client.websocket_connect(
+                                f"/ws/lobby/2?player_id={id1}"
+                            ) as websocket1:
+        
+                                websocket1.send_json({"user_identifier": str(indetifier1), "password": "12345"})
+        
+                                # Chequeamos que la efectivamente la contraseña es incorrecta
+                                response = websocket1.receive_json()
+                                assert response == {
+                                    "error": "Incorrect password",
+                                }


### PR DESCRIPTION
Las partidas ahora pueden ser privadas
    
    - Cambiamos GameIn agregando el campo is_private, el cual debe de ser completado
      al llamar a método POST /api/lobby.
    - Tambien se cambian GameOut devolviendo al cliente el nuevo campo.
    - Se modifica la DB para persistir este nuevo atributo de la clase Game.
    - Se modifican los test para el cambio.