### PR TITLE
Hotfix abandonar partida

### DIFF
--- a/main.py
+++ b/main.py
@@ -455,15 +455,6 @@ async def exit_game(
         await Managers.disconnect_all(game.id)
         games_repo.delete(game)
         return {"status": "success"}
-    await leave_manager.broadcast(
-        {
-            "player_id": player.id,
-            "action": "leave",
-            "player_name": player.name,
-            "players": [player.id for player in game.players],
-        },
-        game.id,
-    )
 
     return {"status": "success"}
 

--- a/tests/test_exit_game.py
+++ b/tests/test_exit_game.py
@@ -88,6 +88,7 @@ class TestGameExits(unittest.TestCase):
         with patch("main.game_repo", self.games_repo), patch(
             "main.player_repo", self.player_repo
         ):
+
             self.game.add_player(self.players[0])
             self.game.add_player(self.players[1])
             self.games_repo.save(self.game)
@@ -122,18 +123,25 @@ class TestGameExits(unittest.TestCase):
         ), self.client.websocket_connect(
             f"/ws/lobby/{self.game.id}?player_id={self.players[1].id}"
         ) as ws:
-            self.game.add_player(self.players[0])
-            self.game.add_player(self.players[1])
-            self.games_repo.save(self.game)
-            rsp = self.client.post(
-                f"/api/lobby/{self.game.id}/exit",
-                json={"identifier": str(self.players[0].identifier)},
-            )
-            self.assertEqual(rsp.status_code, 200)
-            message = ws.receive_json()
-            print(message)
-            self.assertIn("players", message)
-            self.assertEqual(message.get("players"), [self.players[1].id])
+            try:
+                self.game.add_player(self.players[0])
+                self.game.add_player(self.players[1])
+                self.games_repo.save(self.game)
+                ws.send_json({"user_identifier": str(self.players[1].identifier)})
+                rsp = self.client.post(
+                    f"/api/lobby/{self.game.id}/exit",
+                    json={"identifier": str(self.players[0].identifier)},
+                )
+                self.assertEqual(rsp.status_code, 200)
+                message = ws.receive_json()
+                print(message)
+                self.assertIn("players", message)
+                assert message["players"] == [
+                    {"player_id": 2, "player_name": "Lou"},
+                    {"player_id": 3, "player_name": "Lou^2"},
+                ]
+            finally:
+                ws.close()
 
     def test_exit_winner_in_game_ws(self):
         with patch("main.game_repo", self.games_repo), patch(
@@ -141,17 +149,19 @@ class TestGameExits(unittest.TestCase):
         ), self.client.websocket_connect(
             f"/ws/lobby/{self.game.id}?player_id={self.players[1].id}"
         ) as ws:
-            self.game.add_player(self.players[0])
-            self.game.add_player(self.players[1])
-            self.game.started = True
-            self.games_repo.save(self.game)
-            rsp = self.client.post(
-                f"/api/lobby/{self.game.id}/exit",
-                json={"identifier": str(self.players[1].identifier)},
-            )
+            try:
+                self.game.add_player(self.players[0])
+                self.game.add_player(self.players[1])
+                self.game.started = True
+                self.games_repo.save(self.game)
+                rsp = self.client.post(
+                    f"/api/lobby/{self.game.id}/exit",
+                    json={"identifier": str(self.players[1].identifier)},
+                )
 
-            self.assertEqual(rsp.status_code, 200)
-            message = ws.receive_json()
-            assert message is not None
-            print(message)
-            assert message["response"] == self.players[0].id
+                self.assertEqual(rsp.status_code, 200)
+                message = ws.receive_json()
+                print(message)
+                assert message["response"] == self.players[0].id
+            finally:
+                ws.close()


### PR DESCRIPTION
borre las siguientes lineas en exit_game:
wait leave_manager.broadcast(
        {
            "player_id": player.id,
            "action": "leave",
            "player_name": player.name,
            "players": [player.id for player in game.players],
        },
        game.id,
    ) 
para que no se pise con el ws de inout y se pueda integrar bien con front.
Tambien adapte los tests de exit game para este caso e hice make format